### PR TITLE
Add appName config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,17 @@ Each log object contains the following properties:
 - `categoryName` - specified when `log4js` is initialized
 - `data` - if the log message is a string, otherwise omitted
 - `level` - level in human readable format
-- `source` - if provided, will be included 
+- `source` - if provided, will be included
+
+Additional properties can be specified as extra arguments of object type during invocation of log function. Static or constant properties can be specified using the `static` config option.
 
 ### Options
 
 - `type` - string, always `json`
 - `source` - optional string, just sets the property `source`. Example value: `development`
 - `include` - array of properties to include in the log object
-- `colors` - boolean; off by default. If set to true, colorizes the output using log4js default color scheme based on log level. Useful for development, do not use for storing logs.
+- `colors` - boolean; off by default. If set to true, colorizes the output using log4js default color scheme based on log level. Useful for development, do not use for storing logs
+- `static` - object, name value pairs of this object are added to output 
 
 ### Example Config
 
@@ -68,6 +71,9 @@ appenders = [{
   layout: {
     type: 'json',
     source: 'development',
+    static: {
+      appName: 'mysuperbapp'
+    },
     include: ['startTime', 'categoryName'],
   }
 }];

--- a/lib/jsonLayout.js
+++ b/lib/jsonLayout.js
@@ -79,6 +79,13 @@ function jsonLayout(config) {
 
     _.assign(output, overlays);
 
+    // Add appName if specified
+    if (_.has(config, 'appName')) {
+      output.appName = config.appName;
+    }
+
+    // Only include fields specified in 'include' field
+    // if field is specified
     if (config.include && config.include.length) {
       const newOutput = {};
       _.forEach(config.include, (key) => {

--- a/lib/jsonLayout.js
+++ b/lib/jsonLayout.js
@@ -62,6 +62,11 @@ function jsonLayout(config) {
       output.source = config.source;
     }
 
+    // Emit own properties of config.static if specified
+    if (_.has(config, 'static')) {
+      Object.assign(output, config.static);
+    }
+
     const messages = _.isArray(data.data) ? data.data : [data.data];
 
     output.data = formatLogData(messages);
@@ -78,11 +83,6 @@ function jsonLayout(config) {
     }
 
     _.assign(output, overlays);
-
-    // Add appName if specified
-    if (_.has(config, 'appName')) {
-      output.appName = config.appName;
-    }
 
     // Only include fields specified in 'include' field
     // if field is specified

--- a/test/unit/lib/jsonLayout.js
+++ b/test/unit/lib/jsonLayout.js
@@ -146,4 +146,23 @@ describe('log4js-json-layout', function () {
     actual.id.should.equal(123);
     actual.data.should.equal('aaa');
   });
+
+  it('should add static fields when configured', function () {
+    data.data = [{ id: 123, data: 'aaa' }];
+    const actual = JSON.parse(layout({
+      static: { appName: 'testapp', source: 'development' }
+    })(data));
+    actual.id.should.equal(123);
+    actual.data.should.equal('aaa');
+    actual.appName.should.equal('testapp');
+    actual.source.should.equal('development');
+  });
+
+  it('should still pick specific keys when static fields are configured', function () {
+    const actual = layout({
+      static: { appName: 'testapp' },
+      include: ['level', 'data'],
+    })(data);
+    actual.should.deep.equal(JSON.stringify({ level: expected.level, data: expected.data }));
+  });
 });


### PR DESCRIPTION
We have multiple applications pushing logs to one log server and we'd like to differentiate between them in ElasticSearch queries.