### PR TITLE
addLayout function in log4js object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Additional properties can be specified as extra arguments of object type during 
 const log4js = require('log4js');
 const jsonLayout = require('log4js-json-layout');
 
-log4js.layouts.addLayout('json', jsonLayout);
+log4js.addLayout('json', jsonLayout);
 ```
 
 Minimal:


### PR DESCRIPTION
In https://github.com/log4js-node/log4js-node/blob/master/lib/log4js.js
We see that layouts property is no longer exposed:

const log4js = {
  getLogger,
  configure,
  shutdown,
  connectLogger: connectModule(levels()).connectLogger,
  levels: levels(),
  addLayout: layouts.addLayout
};

module.exports = log4js;

Need to update README.md